### PR TITLE
added virtualfish plugins option

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -2,7 +2,7 @@ if set -q $VIRTUALFISH_PYTHON
     set VIRTUALFISH_PYTHON python
 end
 
-eval (eval $VIRTUALFISH_PYTHON -m virtualfish auto_activation 2>/dev/null)
+eval (eval $VIRTUALFISH_PYTHON -m virtualfish $VIRTUALFISH_PLUGINS 2>/dev/null)
 
 if test $status -gt 0
     echo "Please install virtualfish by running `pip install virtualfish`"

--- a/init.fish
+++ b/init.fish
@@ -2,7 +2,7 @@ if set -q $VIRTUALFISH_PYTHON
     set VIRTUALFISH_PYTHON python
 end
 
-eval (eval $VIRTUALFISH_PYTHON -m virtualfish 2>/dev/null)
+eval (eval $VIRTUALFISH_PYTHON -m virtualfish auto_activation 2>/dev/null)
 
 if test $status -gt 0
     echo "Please install virtualfish by running `pip install virtualfish`"


### PR DESCRIPTION
virtualfish plugins can be loaded by setting $VIRTUALFISH_PLUGINS variable to desired plugin names

Example: `set -g VIRTUALFISH_PLUGINS "auto_activation compat_aliases"`
